### PR TITLE
refactor: inject a single mail-sender service in auth module

### DIFF
--- a/src/mail-sender/mail-sender.service.ts
+++ b/src/mail-sender/mail-sender.service.ts
@@ -14,6 +14,8 @@ import {
 export class MailSenderService {
   private transporter: Mail;
 
+  private socials: string;
+
   private logger = new Logger('MailSenderService');
 
   constructor() {
@@ -26,6 +28,9 @@ export class MailSenderService {
       port: config.mail.service.port,
       secure: config.mail.service.secure,
     });
+    this.socials = config.project.socials.map(
+      (social) => `<a href="${social[1]}" style="box-sizing:border-box;color:${config.project.color};font-weight:400;text-decoration:none;font-size:12px;padding:0 5px" target="_blank">${social[0]}</a>`,
+    ).join('');
   }
 
   async sendVerifyEmailMail(
@@ -33,7 +38,6 @@ export class MailSenderService {
     email: string,
     token: string,
   ): Promise<boolean> {
-    const socials = this.createSocials();
     const buttonLink = `${config.project.mailVerificationUrl}?token=${token}`;
 
     const mail = confirmMail
@@ -44,7 +48,7 @@ export class MailSenderService {
       .replace(new RegExp('--ProjectSlogan--', 'g'), config.project.slogan)
       .replace(new RegExp('--ProjectColor--', 'g'), config.project.color)
       .replace(new RegExp('--ProjectLink--', 'g'), config.project.url)
-      .replace(new RegExp('--Socials--', 'g'), socials)
+      .replace(new RegExp('--Socials--', 'g'), this.socials)
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink)
       .replace(
         new RegExp('--TermsOfServiceLink--', 'g'),
@@ -74,8 +78,6 @@ export class MailSenderService {
     email: string,
     token: string,
   ): Promise<boolean> {
-    const socials = this.createSocials();
-
     const buttonLink = `${config.project.mailChangeUrl}?token=${token}`;
 
     const mail = changeMail
@@ -86,7 +88,7 @@ export class MailSenderService {
       .replace(new RegExp('--ProjectSlogan--', 'g'), config.project.slogan)
       .replace(new RegExp('--ProjectColor--', 'g'), config.project.color)
       .replace(new RegExp('--ProjectLink--', 'g'), config.project.url)
-      .replace(new RegExp('--Socials--', 'g'), socials)
+      .replace(new RegExp('--Socials--', 'g'), this.socials)
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink);
 
     const mailOptions = {
@@ -112,7 +114,6 @@ export class MailSenderService {
     email: string,
     token: string,
   ): Promise<boolean> {
-    const socials = this.createSocials();
     const buttonLink = `${config.project.resetPasswordUrl}?token=${token}`;
 
     const mail = resetPassword
@@ -123,7 +124,7 @@ export class MailSenderService {
       .replace(new RegExp('--ProjectSlogan--', 'g'), config.project.slogan)
       .replace(new RegExp('--ProjectColor--', 'g'), config.project.color)
       .replace(new RegExp('--ProjectLink--', 'g'), config.project.url)
-      .replace(new RegExp('--Socials--', 'g'), socials)
+      .replace(new RegExp('--Socials--', 'g'), this.socials)
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink);
 
     const mailOptions = {
@@ -148,7 +149,6 @@ export class MailSenderService {
     name: string,
     email: string,
   ): Promise<boolean> {
-    const socials = this.createSocials();
     const buttonLink = config.project.url;
     const mail = changePasswordInfo
       .replace(new RegExp('--PersonName--', 'g'), name)
@@ -158,7 +158,7 @@ export class MailSenderService {
       .replace(new RegExp('--ProjectSlogan--', 'g'), config.project.slogan)
       .replace(new RegExp('--ProjectColor--', 'g'), config.project.color)
       .replace(new RegExp('--ProjectLink--', 'g'), config.project.url)
-      .replace(new RegExp('--Socials--', 'g'), socials)
+      .replace(new RegExp('--Socials--', 'g'), this.socials)
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink);
 
     const mailOptions = {
@@ -177,13 +177,5 @@ export class MailSenderService {
       }
       resolve(true);
     }));
-  }
-
-  private createSocials(): string {
-    let socials = '';
-    config.project.socials.forEach((social) => {
-      socials += `<a href="${social[1]}" style="box-sizing:border-box;color:${config.project.color};font-weight:400;text-decoration:none;font-size:12px;padding:0 5px" target="_blank">${social[0]}</a>`;
-    });
-    return socials;
   }
 }

--- a/src/mail-sender/mail-sender.service.ts
+++ b/src/mail-sender/mail-sender.service.ts
@@ -1,18 +1,39 @@
-import { Logger } from '@nestjs/common';
-import * as nodemailer from 'nodemailer';
+import { Injectable, Logger } from '@nestjs/common';
+import { createTransport } from 'nodemailer';
+import * as Mail from 'nodemailer/lib/mailer';
+
 import config from '../config';
 import {
-  changeMail, changePasswordInfo, confirmMail, resetPassword,
+  changeMail,
+  changePasswordInfo,
+  confirmMail,
+  resetPassword,
 } from './templates';
 
+@Injectable()
 export class MailSenderService {
-  static async sendVerifyEmailMail(
+  private transporter: Mail;
+
+  private logger = new Logger('MailSenderService');
+
+  constructor() {
+    this.transporter = createTransport({
+      auth: {
+        user: config.mail.service.user,
+        pass: config.mail.service.pass,
+      },
+      host: config.mail.service.host,
+      port: config.mail.service.port,
+      secure: config.mail.service.secure,
+    });
+  }
+
+  async sendVerifyEmailMail(
     name: string,
     email: string,
     token: string,
   ): Promise<boolean> {
-    const transporter = MailSenderService.createTransporter();
-    const socials = MailSenderService.createSocials();
+    const socials = this.createSocials();
     const buttonLink = `${config.project.mailVerificationUrl}?token=${token}`;
 
     const mail = confirmMail
@@ -31,30 +52,29 @@ export class MailSenderService {
       );
 
     const mailOptions = {
-      from: `"${config.mail.senderCredentials.name}" <${
-        config.mail.senderCredentials.email
-      }>`,
+      from: `"${config.mail.senderCredentials.name}" <${config.mail.senderCredentials.email}>`,
       to: email, // list of receivers (separated by ,)
       subject: `Welcome to ${config.project.name} ${name}! Confirm Your Email`,
       html: mail,
     };
 
-    return new Promise<boolean>((resolve) => transporter.sendMail(mailOptions, async (error) => {
+    return new Promise<boolean>((resolve) => this.transporter.sendMail(mailOptions, async (error) => {
       if (error) {
-        Logger.warn('Mail sending failed, check your service credentials.');
+        this.logger.warn(
+          'Mail sending failed, check your service credentials.',
+        );
         resolve(false);
       }
       resolve(true);
     }));
   }
 
-  static async sendChangeEmailMail(
+  async sendChangeEmailMail(
     name: string,
     email: string,
     token: string,
   ): Promise<boolean> {
-    const transporter = MailSenderService.createTransporter();
-    const socials = MailSenderService.createSocials();
+    const socials = this.createSocials();
 
     const buttonLink = `${config.project.mailChangeUrl}?token=${token}`;
 
@@ -70,31 +90,29 @@ export class MailSenderService {
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink);
 
     const mailOptions = {
-      from: `"${config.mail.senderCredentials.name}" <${
-        config.mail.senderCredentials.email
-      }>`,
+      from: `"${config.mail.senderCredentials.name}" <${config.mail.senderCredentials.email}>`,
       to: email, // list of receivers (separated by ,)
       subject: `Change Your ${config.project.name} Account's Email`,
       html: mail,
     };
 
-    return new Promise<boolean>((resolve) => transporter.sendMail(mailOptions, async (error) => {
+    return new Promise<boolean>((resolve) => this.transporter.sendMail(mailOptions, async (error) => {
       if (error) {
-        Logger.warn('Mail sending failed, check your service credentials.');
+        this.logger.warn(
+          'Mail sending failed, check your service credentials.',
+        );
         resolve(false);
       }
       resolve(true);
     }));
   }
 
-  static async sendResetPasswordMail(
+  async sendResetPasswordMail(
     name: string,
     email: string,
     token: string,
   ): Promise<boolean> {
-    const transporter = MailSenderService.createTransporter();
-    const socials = MailSenderService.createSocials();
-
+    const socials = this.createSocials();
     const buttonLink = `${config.project.resetPasswordUrl}?token=${token}`;
 
     const mail = resetPassword
@@ -109,26 +127,28 @@ export class MailSenderService {
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink);
 
     const mailOptions = {
-      from: `"${config.mail.senderCredentials.name}" <${
-        config.mail.senderCredentials.email
-      }>`,
+      from: `"${config.mail.senderCredentials.name}" <${config.mail.senderCredentials.email}>`,
       to: email, // list of receivers (separated by ,)
       subject: `Reset Your ${config.project.name} Account's Password`,
       html: mail,
     };
 
-    return new Promise<boolean>((resolve) => transporter.sendMail(mailOptions, async (error) => {
+    return new Promise<boolean>((resolve) => this.transporter.sendMail(mailOptions, async (error) => {
       if (error) {
-        Logger.warn('Mail sending failed, check your service credentials.');
+        this.logger.warn(
+          'Mail sending failed, check your service credentials.',
+        );
         resolve(false);
       }
       resolve(true);
     }));
   }
 
-  static async sendPasswordChangeInfoMail(name: string, email: string):Promise<boolean> {
-    const transporter = MailSenderService.createTransporter();
-    const socials = MailSenderService.createSocials();
+  async sendPasswordChangeInfoMail(
+    name: string,
+    email: string,
+  ): Promise<boolean> {
+    const socials = this.createSocials();
     const buttonLink = config.project.url;
     const mail = changePasswordInfo
       .replace(new RegExp('--PersonName--', 'g'), name)
@@ -142,43 +162,27 @@ export class MailSenderService {
       .replace(new RegExp('--ButtonLink--', 'g'), buttonLink);
 
     const mailOptions = {
-      from: `"${config.mail.senderCredentials.name}" <${
-        config.mail.senderCredentials.email
-      }>`,
+      from: `"${config.mail.senderCredentials.name}" <${config.mail.senderCredentials.email}>`,
       to: email, // list of receivers (separated by ,)
       subject: `Your ${config.project.name} Account's Password is Changed`,
       html: mail,
     };
 
-    return new Promise<boolean>((resolve) => transporter.sendMail(mailOptions, async (error) => {
+    return new Promise<boolean>((resolve) => this.transporter.sendMail(mailOptions, async (error) => {
       if (error) {
-        Logger.warn('Mail sending failed, check your service credentials.');
+        this.logger.warn(
+          'Mail sending failed, check your service credentials.',
+        );
         resolve(false);
       }
       resolve(true);
     }));
   }
 
-  private static createTransporter() {
-    return nodemailer.createTransport({
-      auth: {
-        user: config.mail.service.user,
-        pass: config.mail.service.pass,
-      },
-      host: config.mail.service.host,
-      port: config.mail.service.port,
-      secure: config.mail.service.secure,
-    });
-  }
-
-  private static createSocials(): string {
+  private createSocials(): string {
     let socials = '';
     config.project.socials.forEach((social) => {
-      socials += `<a href="${social[1]}" style="box-sizing:border-box;color:${
-        config.project.color
-      };font-weight:400;text-decoration:none;font-size:12px;padding:0 5px" target="_blank">${
-        social[0]
-      }</a>`;
+      socials += `<a href="${social[1]}" style="box-sizing:border-box;color:${config.project.color};font-weight:400;text-decoration:none;font-size:12px;padding:0 5px" target="_blank">${social[0]}</a>`;
     });
     return socials;
   }


### PR DESCRIPTION
#### Issue

Closes: https://github.com/ahmetuysal/nest-hackathon-starter/issues/23

#### Description

Refactors `MailSenderService` - It's now a Injectable class

1. Import in the appropriate module `imports: [MailSenderModule]`
2. Declare in the service constructor `constructor(private readonly mailSenderService: MailSenderService){}`
3. Use like this `await this.mailSenderService.sendChangeEmailMail(name, oldEmail, token);`

#### Notes

1. Didn't use `ConfigService`, as the app depends on re-using the `config.ts` file, for example for the JWT secrets. Kept the changes to the minimum. Here's how it would look

```ts
  constructor(private readonly configService: ConfigService) {
    this.transporter = createTransport({
      host: configService.get('MAIL_HOST'),
      port: configService.get('PORT'),
      secure: configService.get('SECURE')
      auth: {
        user: configService.get('MAIL_USER'),
        pass: configService.get('MAIL_PASS'),
      },
    });
  }
```

2. The create socials could be also calculated only once, didn't want to interfere.
3. There are some annoying prettier changes, that I saw far too late to revert. Let me know if there are blockers.